### PR TITLE
added the promised link to terra station when no mnemonic is provided

### DIFF
--- a/bot/helpers.py
+++ b/bot/helpers.py
@@ -156,7 +156,8 @@ def vote_on_proposal_details(update, context):
     message = ''
 
     if not is_wallet_provided():
-        message = f"😢 *You can't vote, no MNEMONIC key provided.* 😢"
+        message = f"😢 *You can't vote, no MNEMONIC key provided.*\n" \
+                  f"Please visit https://station.terra.money/governance to vote.😢"
     elif user_id not in ALLOWED_USER_IDS:
         message = f'😢 *You are not allowed to vote because your id ({user_id}) is not whitelisted!* 😢'
     else:


### PR DESCRIPTION
## Description

It was promised that there will be a link to the terra station /governance if a node operator didn't specify a mnemonic. 

## Fixes (issue)

Did you fix something? Leave empty if this PR contains just the new feature.


## Improvements

It was promised that there will be a link to the terra station /governance if a node operator didn't specify a mnemonic. 

## How Has This Been Tested?
Manually

## Checklist:
If you have any comments regarding one of these points just write it down.

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
