### PR TITLE
Bug/remove accidently inserted word

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 DEBUG = bool(os.environ.get('DEBUG') == "True")
 TELEGRAM_BOT_TOKEN = os.environ['TELEGRAM_BOT_TOKEN']
 SLACK_WEBHOOK = os.environ.get('SLACK_WEBHOOK')
-adjustLCD_ENDPOINT = f"{os.environ['LCD_ENDPOINT']}:1317" if os.environ.get('LCD_ENDPOINT') else "lcd.terra.dev"
+LCD_ENDPOINT = f"{os.environ['LCD_ENDPOINT']}:1317" if os.environ.get('LCD_ENDPOINT') else "lcd.terra.dev"
 
 # Set NODE_IP depending on mode (if None, certain node health jobs are not executed)
 if DEBUG:

--- a/bot/helpers.py
+++ b/bot/helpers.py
@@ -156,7 +156,8 @@ def vote_on_proposal_details(update, context):
     message = ''
 
     if not is_wallet_provided():
-        message = f"😢 *You can't vote, no MNEMONIC key provided.* 😢"
+        message = f"😢 *You can't vote, no MNEMONIC key provided.*\n" \
+                  f"Please visit https://station.terra.money/governance to vote.😢"
     elif user_id not in ALLOWED_USER_IDS:
         message = f'😢 *You are not allowed to vote because your id ({user_id}) is not whitelisted!* 😢'
     else:


### PR DESCRIPTION
## Description

Due to the number of validator nodes, the "My nodes" became too long for a telegram message.
Now the node addresses are shown in two columns to circumvent this issue.

## Fixes (issue)

Yes "reply markup too long" is fixed


## Improvements

Did you improve something? Why did you do this? Why do you think it's better?

## How Has This Been Tested?

Manually

## Checklist:
If you have any comments regarding one of these points just write it down.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
