### PR TITLE
my nodes is now shown in two columns

### DIFF
--- a/bot/helpers.py
+++ b/bot/helpers.py
@@ -65,8 +65,16 @@ def get_my_nodes_menu_buttons(user_data):
 
     keyboard = [[]]
 
+    count = 0
     for address in user_data['nodes'].keys():
-        keyboard.append([InlineKeyboardButton("📡 " + address, callback_data='node_details-' + address)])
+        new_button = InlineKeyboardButton("📡 " + address, callback_data='node_details-' + address)
+
+        if count % 2 == 0:
+            keyboard.append([new_button])
+        else:
+            # Add every second entry to the last row so that we have two columns
+            keyboard[len(keyboard)-1].append(new_button)
+        count += 1
 
     keyboard.append([InlineKeyboardButton('1️⃣ ADD NODE', callback_data='add_node')])
     keyboard.append([

--- a/storage/dummy_placeholder.txt
+++ b/storage/dummy_placeholder.txt
@@ -1,1 +1,0 @@
-This file makes sure that the storage/ folder exists on github


### PR DESCRIPTION
## Description

Due to the number of validator nodes, the "My nodes" became too long for a telegram message.
Now the node addresses are shown in two columns to circumvent this issue.

## Fixes (issue)

Yes "reply markup too long" is fixed


## Improvements

Did you improve something? Why did you do this? Why do you think it's better?

## How Has This Been Tested?

Manually

## Checklist:
If you have any comments regarding one of these points just write it down.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
